### PR TITLE
AD - Table Component for HelpRequest plus tests

### DIFF
--- a/frontend/src/main/components/HelpRequest/HelpRequestTable.js
+++ b/frontend/src/main/components/HelpRequest/HelpRequestTable.js
@@ -1,0 +1,76 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/helpRequestUtils";
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function HelpRequestTable({ requests, currentUser }) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/helprequest/edit/${cell.row.values.id}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/helprequest/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      Header: "id",
+      accessor: "id", // accessor is the "key" in the data
+    },
+    {
+      Header: "Email",
+      accessor: "requesterEmail",
+    },
+    {
+      Header: "Team ID",
+      accessor: "teamID",
+    },
+    {
+      Header: "Table or Breakout Room",
+      accessor: "tableOrBreakoutRoom",
+    },
+    {
+      Header: "Explanation",
+      accessor: "explanation",
+    },
+    {
+      Header: "Solved",
+      accessor: "solved",
+    },
+    {
+      Header: "Date",
+      accessor: "localDateTime",
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(
+      ButtonColumn("Edit", "primary", editCallback, "HelpRequestTable"),
+    );
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, "HelpRequestTable"),
+    );
+  }
+
+  return (
+    <OurTable data={requests} columns={columns} testid={"HelpRequestTable"} />
+  );
+}

--- a/frontend/src/main/utils/helpRequestUtils.js
+++ b/frontend/src/main/utils/helpRequestUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/helprequest",
+    method: "DELETE",
+    params: {
+      id: cell.row.values.id,
+    },
+  };
+}

--- a/frontend/src/stories/components/HelpRequest/HelpRequestTable.stories.js
+++ b/frontend/src/stories/components/HelpRequest/HelpRequestTable.stories.js
@@ -1,0 +1,44 @@
+import React from "react";
+import HelpRequestTable from "main/components/HelpRequest/HelpRequestTable";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/HelpRequest/HelpRequestTable",
+  component: HelpRequestTable,
+};
+
+const Template = (args) => {
+  return <HelpRequestTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  requests: [],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+  requests: helpRequestFixtures.threeRequests,
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+  requests: helpRequestFixtures.threeRequests,
+  currentUser: currentUserFixtures.adminUser,
+};
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.delete("/api/helprequest", () => {
+      return HttpResponse.json(
+        { message: "Request deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.js
+++ b/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.js
@@ -1,0 +1,220 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import HelpRequestTable from "main/components/HelpRequest/HelpRequestTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe("UserTable tests", () => {
+  const queryClient = new QueryClient();
+
+  test("Has the expected column headers and content for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            requests={helpRequestFixtures.threeRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const expectedHeaders = [
+      "id",
+      "Email",
+      "Team ID",
+      "Table or Breakout Room",
+      "Explanation",
+      "Solved",
+      "Date",
+    ];
+    const expectedFields = [
+      "id",
+      "requesterEmail",
+      "teamID",
+      "tableOrBreakoutRoom",
+      "explanation",
+      "solved",
+      "localDateTime",
+    ];
+    const testId = "HelpRequestTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+
+    const editButton = screen.queryByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).not.toBeInTheDocument();
+
+    const deleteButton = screen.queryByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).not.toBeInTheDocument();
+  });
+
+  test("Has the expected colum headers and content for adminUser", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            requests={helpRequestFixtures.threeRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const expectedHeaders = [
+      "id",
+      "Email",
+      "Team ID",
+      "Table or Breakout Room",
+      "Explanation",
+      "Solved",
+      "Date",
+    ];
+    const expectedFields = [
+      "id",
+      "requesterEmail",
+      "teamID",
+      "tableOrBreakoutRoom",
+      "explanation",
+      "solved",
+      "localDateTime",
+    ];
+    const testId = "HelpRequestTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
+
+  test("Edit button navigates to the edit page for admin user", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            requests={helpRequestFixtures.threeRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`HelpRequestTable-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+
+    const editButton = screen.getByTestId(
+      `HelpRequestTable-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+
+    fireEvent.click(editButton);
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith("/helprequest/edit/1"),
+    );
+  });
+
+  test("Delete button calls delete callback", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/helprequest")
+      .reply(200, { message: "Request deleted" });
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            requests={helpRequestFixtures.threeRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert - check that the expected content is rendered
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`HelpRequestTable-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+
+    const deleteButton = screen.getByTestId(
+      `HelpRequestTable-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    // act - click the delete button
+    fireEvent.click(deleteButton);
+
+    // assert - check that the delete endpoint was called
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+  });
+});

--- a/frontend/src/tests/utils/helpRequestUtils.test.js
+++ b/frontend/src/tests/utils/helpRequestUtils.test.js
@@ -1,0 +1,51 @@
+import {
+  onDeleteSuccess,
+  cellToAxiosParamsDelete,
+} from "main/utils/helpRequestUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+describe("helpRequestUtils", () => {
+  describe("onDeleteSuccess", () => {
+    test("It puts the message on console.log and in a toast", () => {
+      // arrange
+      const restoreConsole = mockConsole();
+
+      // act
+      onDeleteSuccess("abc");
+
+      // assert
+      expect(mockToast).toHaveBeenCalledWith("abc");
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toMatch("abc");
+
+      restoreConsole();
+    });
+  });
+  describe("cellToAxiosParamsDelete", () => {
+    test("It returns the correct params", () => {
+      // arrange
+      const cell = { row: { values: { id: 17 } } };
+
+      // act
+      const result = cellToAxiosParamsDelete(cell);
+
+      // assert
+      expect(result).toEqual({
+        url: "/api/helprequest",
+        method: "DELETE",
+        params: { id: 17 },
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes #47 
I implemented the HelpRequestTable plus tests so that it works on storybook. It can be seen here (https://680adca96c3e5e0ebe767db7-xdfjkfeniu.chromatic.com/?path=/story/components-helprequest-helprequesttable--three-items-admin-user). 
<img width="1194" alt="Screenshot 2025-05-01 at 3 12 20 PM" src="https://github.com/user-attachments/assets/ac32b181-1c02-4ad3-86a4-80010f45edd3" />
